### PR TITLE
Add Arch & Manjaro (pacman) support + [Not Working] Alpine Support

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -218,6 +218,17 @@ install_using_package_manager() {
       fi
       ;;
     arch)
+      if [[ $1 == $PYTHON_COMMAND ]]
+      then
+        package="python3 cmake gcc"
+      fi
+
+      # overwrite node to nodejs
+      if [[ $1 == "node" ]]
+      then
+        package="nodejs"
+      fi
+
       if [[ $2 ]]
       then
         echo "sudo pacman -S --noconfirm $package"

--- a/setup.sh
+++ b/setup.sh
@@ -226,7 +226,7 @@ install_using_package_manager() {
       # overwrite node to nodejs
       if [[ $1 == "node" ]]
       then
-        package="nodejs"
+        package="nodejs npm"
       fi
 
       if [[ $2 ]]

--- a/setup.sh
+++ b/setup.sh
@@ -217,6 +217,13 @@ install_using_package_manager() {
         sudo yum install -y $package
       fi
       ;;
+    arch)
+      if [[ $2 ]]
+      then
+        echo "sudo pacman -S --noconfirm $package"
+      else
+        sudo pacman -S --noconfirm $package
+      fi
     *)
       echo ""
       echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -235,6 +235,7 @@ install_using_package_manager() {
       else
         sudo pacman -S --noconfirm $package
       fi
+      ;;
     *)
       echo ""
       echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -236,6 +236,25 @@ install_using_package_manager() {
         sudo pacman -S --noconfirm $package
       fi
       ;;
+    alpine)
+      if [[ $1 == $PYTHON_COMMAND ]]
+      then
+        package="python3 cmake gcc"
+      fi
+
+      # overwrite node to nodejs
+      if [[ $1 == "node" ]]
+      then
+        package="nodejs npm"
+      fi
+
+      if [[ $2 ]]
+      then
+        echo "sudo apk add $package"
+      else
+        sudo apk add $package
+      fi
+      ;;
     *)
       echo ""
       echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -346,9 +346,15 @@ check_and_install_dependencies curl
 # check for python3
 check_and_install_dependencies $PYTHON_COMMAND
 
+# alpine needs some additional build tools
+if [[ $OS == "linux" && $ID == "alpine" ]]
+then
+  apk add python-dev gfortran py-pip build-base
+fi
+
 # check for pip
 # except on fedora, arch, and manjaro, where pip is installed with python
-if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" ]]
+if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" && $ID != "alpine" ]]
 then
   check_and_install_dependencies $PIP_COMMAND
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -346,12 +346,6 @@ check_and_install_dependencies curl
 # check for python3
 check_and_install_dependencies $PYTHON_COMMAND
 
-# alpine needs some additional build tools
-if [[ $OS == "linux" && $ID == "alpine" ]]
-then
-  apk add python-dev gfortran py-pip build-base
-fi
-
 # check for pip
 # except on fedora, arch, and manjaro, where pip is installed with python
 if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" && $ID != "alpine" ]]
@@ -404,6 +398,13 @@ export PATH=$PATH:~/.local/bin
 # this will exit when the script ends
 # we cd into the `roboflow` folder we just created so we run as the same user that just created it; this prevents an issue when running as root in docker
 cd roboflow && npx @roboflow/inference-server --yes &> /dev/null &
+
+# alpine needs some additional build tools
+if [[ $OS == "linux" && $ID == "alpine" ]]
+then
+  apk add build-base g++ gfortran jpeg-dev libjpeg make py3-numpy py3-numpy-dev py3-pip python3-dev zlib-dev
+  $PIP_COMMAND -v --log /tmp/pip.log install wheel
+fi
 
 # pip install the requirements
 # and run the roboflow notebook

--- a/setup.sh
+++ b/setup.sh
@@ -328,8 +328,8 @@ check_and_install_dependencies curl
 check_and_install_dependencies $PYTHON_COMMAND
 
 # check for pip
-# except on arch and manjaro, where pip is installed with python
-if [[ $OS != "linux" || $ID != "arch" && $ID != "manjaro" ]]
+# except on fedora, arch, and manjaro, where pip is installed with python
+if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" ]]
 then
   check_and_install_dependencies $PIP_COMMAND
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -217,7 +217,7 @@ install_using_package_manager() {
         sudo yum install -y $package
       fi
       ;;
-    arch)
+    arch | manjaro)
       if [[ $1 == $PYTHON_COMMAND ]]
       then
         package="python3 cmake gcc"

--- a/setup.sh
+++ b/setup.sh
@@ -326,7 +326,13 @@ check_and_install_dependencies curl
 
 # check for python3
 check_and_install_dependencies $PYTHON_COMMAND
-check_and_install_dependencies $PIP_COMMAND
+
+# check for pip
+# except on arch and manjaro, where pip is installed with python
+if [[ $OS != "linux" || $ID != "arch" && $ID != "manjaro" ]]
+then
+  check_and_install_dependencies $PIP_COMMAND
+fi
 
 # if OS is linux and ID is amzn install basic dependencies
 if [[ $OS == "linux" && $ID == "amzn" ]]


### PR DESCRIPTION
# Description

This adds support for `archlinux` and `manjaro` via the `pacman` package manager.

This also gets most of the way there for Alpine / `apk` support. The python dependencies build & the notebook starts, but TFjs fails due to musl / glibc incompatibilities. I'd like to include this in case we switch to using our non-JS based inference server someday though.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

In docker on a x86 VM (working with arch and manjaro but not fully working on alpine).

## Any specific deployment considerations

None

## Docs

-  Not needed.
