### PR TITLE
FreeBSD Support

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -287,6 +287,25 @@ install_using_package_manager() {
         sudo zypper install -y $package
       fi
       ;;
+    gentoo)
+      if [[ $1 == $PYTHON_COMMAND ]]
+      then
+        package="python"
+      fi
+
+      # overwrite node to nodejs
+      if [[ $1 == "node" ]]
+      then
+        package="nodejs npm"
+      fi
+
+      if [[ $2 ]]
+      then
+        echo "sudo emerge $package"
+      else
+        sudo emerge $package
+      fi
+      ;;
     *)
       echo ""
       echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -218,6 +218,17 @@ install_using_package_manager() {
       fi
       ;;
     arch)
+      if [[ $1 == $PYTHON_COMMAND ]]
+      then
+        package="python3 cmake gcc"
+      fi
+
+      # overwrite node to nodejs
+      if [[ $1 == "node" ]]
+      then
+        package="nodejs"
+      fi
+
       if [[ $2 ]]
       then
         echo "sudo pacman -S --noconfirm $package"

--- a/setup.sh
+++ b/setup.sh
@@ -493,10 +493,11 @@ then
   $PIP_COMMAND -v --log /tmp/pip.log install wheel
 fi
 
-# on freebsd, install the prebuilt numpy and matplotlib wheels
+# on freebsd, install the prebuilt numpy and matplotlib wheels plus other dependencies
 if [[ $OS == "freebsd" ]]
 then
-  pkg install -y py39-numpy py39-matplotlib
+  sudo kldload linux64.ko
+  sudo pkg install -y py39-numpy py39-matplotlib py39-pillow zlib libjpeg-turbo linux-c7-zlib-devel
 fi
 
 # pip install the requirements

--- a/setup.sh
+++ b/setup.sh
@@ -288,6 +288,8 @@ install_using_package_manager() {
       fi
       ;;
     gentoo)
+      USE=""
+
       if [[ $1 == $PYTHON_COMMAND ]]
       then
         package="dev-lang/python"
@@ -303,13 +305,14 @@ install_using_package_manager() {
       if [[ $1 == "node" ]]
       then
         package="net-libs/nodejs"
+        USE=" USE=npm"
       fi
 
       if [[ $2 ]]
       then
-        echo "sudo emerge $package"
+        echo "sudo$USE emerge $package"
       else
-        sudo emerge $package
+        sudo$USE emerge $package
       fi
       ;;
     *)

--- a/setup.sh
+++ b/setup.sh
@@ -226,7 +226,7 @@ install_using_package_manager() {
       # overwrite node to nodejs
       if [[ $1 == "node" ]]
       then
-        package="nodejs"
+        package="nodejs npm"
       fi
 
       if [[ $2 ]]

--- a/setup.sh
+++ b/setup.sh
@@ -305,14 +305,14 @@ install_using_package_manager() {
       if [[ $1 == "node" ]]
       then
         package="net-libs/nodejs"
-        USE=" USE=npm"
+        export USE="npm"
       fi
 
       if [[ $2 ]]
       then
-        echo "sudo$USE emerge $package"
+        echo "sudo emerge $package"
       else
-        sudo$USE emerge $package
+        sudo emerge $package
       fi
       ;;
     *)

--- a/setup.sh
+++ b/setup.sh
@@ -217,6 +217,13 @@ install_using_package_manager() {
         sudo yum install -y $package
       fi
       ;;
+    arch)
+      if [[ $2 ]]
+      then
+        echo "sudo pacman -S --noconfirm $package"
+      else
+        sudo pacman -S --noconfirm $package
+      fi
     *)
       echo ""
       echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -124,6 +124,12 @@ install_using_package_manager() {
   linux)
     source /etc/os-release
 
+    # if the ID starts with opensuse, simplify it to opensuse
+    if [[ $ID =~ "opensuse" ]]
+    then
+      ID="opensuse"
+    fi
+
     package=$1
     case $ID in
     debian | ubuntu | linuxmint | mint)

--- a/setup.sh
+++ b/setup.sh
@@ -497,7 +497,8 @@ fi
 if [[ $OS == "freebsd" ]]
 then
   sudo kldload linux64.ko
-  sudo pkg install -y py39-numpy py39-matplotlib py39-pillow zlib libjpeg-turbo linux-c7-zlib-devel
+  $PYTHON_COMMAND -m pip install --upgrade pip
+  sudo pkg install -y py39-numpy py39-matplotlib py39-pillow zlib libjpeg-turbo linux-c7-zlib-devel boost-all py39-boost-libs
 fi
 
 # pip install the requirements

--- a/setup.sh
+++ b/setup.sh
@@ -498,7 +498,7 @@ if [[ $OS == "freebsd" ]]
 then
   sudo kldload linux64.ko
   $PYTHON_COMMAND -m pip install --upgrade pip
-  sudo pkg install -y py39-numpy py39-matplotlib py39-pillow zlib libjpeg-turbo linux-c7-zlib-devel boost-all py39-boost-libs
+  sudo pkg install -y py39-numpy py39-matplotlib py39-pillow zlib-ng libjpeg-turbo linux-c7-zlib-devel boost-all py39-boost-libs
 fi
 
 # pip install the requirements

--- a/setup.sh
+++ b/setup.sh
@@ -358,16 +358,16 @@ install_using_package_manager() {
     ;;
   
   freebsd)
-    if [[ $1 == $PYTHON_COMMAND ]]
-      then
-        package="python39 py39-pip cmake gcc"
-      fi
+    if [[ $1 == $PYTHON_COMMAND || $1 == $PIP_COMMAND ]]
+    then
+      package="python39 py39-pip cmake gcc"
+    fi
 
-      # overwrite node to nodejs
-      if [[ $1 == "node" ]]
-      then
-        package="node npm"
-      fi
+    # overwrite node to nodejs
+    if [[ $1 == "node" ]]
+    then
+      package="node npm"
+    fi
 
     if [[ $2 ]]
     then

--- a/setup.sh
+++ b/setup.sh
@@ -235,6 +235,7 @@ install_using_package_manager() {
       else
         sudo pacman -S --noconfirm $package
       fi
+      ;;
     *)
       echo ""
       echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -107,6 +107,13 @@ then
     PYTHON_COMMAND="python3.8"
     PIP_COMMAND="pip3.8"
   fi
+
+  # for suse (ID starts with opensuse) use python3.9 and pip3.9 (because they're in zypper)
+  if [[ $ID =~ "opensuse" ]]
+  then
+    PYTHON_COMMAND="python3.9"
+    PIP_COMMAND="pip3.9"
+  fi
 fi
 
 # modified install_using_package_manager function which accepts a second argument which,
@@ -253,6 +260,25 @@ install_using_package_manager() {
         echo "sudo apk add $package"
       else
         sudo apk add $package
+      fi
+      ;;
+    opensuse)
+      if [[ $1 == $PYTHON_COMMAND ]]
+      then
+        package="python39 python39-pip cmake gcc"
+      fi
+
+      # overwrite node to nodejs
+      if [[ $1 == "node" ]]
+      then
+        package="nodejs npm"
+      fi
+
+      if [[ $2 ]]
+      then
+        echo "sudo zypper install -y $package"
+      else
+        sudo zypper install -y $package
       fi
       ;;
     *)

--- a/setup.sh
+++ b/setup.sh
@@ -493,6 +493,12 @@ then
   $PIP_COMMAND -v --log /tmp/pip.log install wheel
 fi
 
+# on freebsd, install the prebuilt numpy and matplotlib wheels
+if [[ $OS == "freebsd" ]]
+then
+  $PIP_COMMAND -v --log /tmp/pip.log install py39-numpy py39-matplotlib
+fi
+
 # pip install the requirements
 # and run the roboflow notebook
 $PIP_COMMAND install -v --log /tmp/pip.log roboflow notebook

--- a/setup.sh
+++ b/setup.sh
@@ -236,6 +236,25 @@ install_using_package_manager() {
         sudo pacman -S --noconfirm $package
       fi
       ;;
+    alpine)
+      if [[ $1 == $PYTHON_COMMAND ]]
+      then
+        package="python3 cmake gcc"
+      fi
+
+      # overwrite node to nodejs
+      if [[ $1 == "node" ]]
+      then
+        package="nodejs npm"
+      fi
+
+      if [[ $2 ]]
+      then
+        echo "sudo apk add $package"
+      else
+        sudo apk add $package
+      fi
+      ;;
     *)
       echo ""
       echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -496,7 +496,7 @@ fi
 # on freebsd, install the prebuilt numpy and matplotlib wheels
 if [[ $OS == "freebsd" ]]
 then
-  $PIP_COMMAND -v --log /tmp/pip.log install py39-numpy py39-matplotlib
+  pkg install -y py39-numpy py39-matplotlib
 fi
 
 # pip install the requirements

--- a/setup.sh
+++ b/setup.sh
@@ -346,9 +346,15 @@ check_and_install_dependencies curl
 # check for python3
 check_and_install_dependencies $PYTHON_COMMAND
 
+# alpine needs some additional build tools
+if [[ $OS == "linux" && $ID == "alpine" ]]
+then
+  apk add python-dev gfortran py-pip build-base
+fi
+
 # check for pip
 # except on fedora, arch, and manjaro, where pip is installed with python
-if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" ]]
+if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" && $ID != "alpine" ]]
 then
   check_and_install_dependencies $PIP_COMMAND
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -290,13 +290,19 @@ install_using_package_manager() {
     gentoo)
       if [[ $1 == $PYTHON_COMMAND ]]
       then
-        package="python"
+        package="dev-lang/python"
+      fi
+
+      # for pip, it's dev-python/pip
+      if [[ $1 == $PIP_COMMAND ]]
+      then
+        package="dev-python/pip"
       fi
 
       # overwrite node to nodejs
       if [[ $1 == "node" ]]
       then
-        package="nodejs npm"
+        package="net-libs/nodejs"
       fi
 
       if [[ $2 ]]

--- a/setup.sh
+++ b/setup.sh
@@ -346,12 +346,6 @@ check_and_install_dependencies curl
 # check for python3
 check_and_install_dependencies $PYTHON_COMMAND
 
-# alpine needs some additional build tools
-if [[ $OS == "linux" && $ID == "alpine" ]]
-then
-  apk add python-dev gfortran py-pip build-base
-fi
-
 # check for pip
 # except on fedora, arch, and manjaro, where pip is installed with python
 if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" && $ID != "alpine" ]]
@@ -404,6 +398,13 @@ export PATH=$PATH:~/.local/bin
 # this will exit when the script ends
 # we cd into the `roboflow` folder we just created so we run as the same user that just created it; this prevents an issue when running as root in docker
 cd roboflow && npx @roboflow/inference-server --yes &> /dev/null &
+
+# alpine needs some additional build tools
+if [[ $OS == "linux" && $ID == "alpine" ]]
+then
+  apk add build-base g++ gfortran jpeg-dev libjpeg make py3-numpy py3-numpy-dev py3-pip python3-dev zlib-dev
+  $PIP_COMMAND -v --log /tmp/pip.log install wheel
+fi
 
 # pip install the requirements
 # and run the roboflow notebook

--- a/setup.sh
+++ b/setup.sh
@@ -116,6 +116,13 @@ then
   fi
 fi
 
+# if freebsd, use python3.9 and pip3.9
+if [[ $OS == "freebsd" ]]
+then
+  PYTHON_COMMAND="python3.9"
+  PIP_COMMAND="pip3.9"
+fi
+
 # modified install_using_package_manager function which accepts a second argument which,
 # when true, returns the command that will be run (so the calling code can preview it for the user),
 # and when false actually runs the command
@@ -347,6 +354,26 @@ install_using_package_manager() {
 
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       fi
+    fi
+    ;;
+  
+  freebsd)
+    if [[ $1 == $PYTHON_COMMAND ]]
+      then
+        package="python39 py39-pip cmake gcc"
+      fi
+
+      # overwrite node to nodejs
+      if [[ $1 == "node" ]]
+      then
+        package="node npm"
+      fi
+
+    if [[ $2 ]]
+    then
+      echo "sudo pkg install -y $package"
+    else
+      sudo pkg install -y $package
     fi
     ;;
 

--- a/setup.sh
+++ b/setup.sh
@@ -328,8 +328,8 @@ check_and_install_dependencies curl
 check_and_install_dependencies $PYTHON_COMMAND
 
 # check for pip
-# except on arch and manjaro, where pip is installed with python
-if [[ $OS != "linux" || $ID != "arch" && $ID != "manjaro" ]]
+# except on fedora, arch, and manjaro, where pip is installed with python
+if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" ]]
 then
   check_and_install_dependencies $PIP_COMMAND
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -217,7 +217,7 @@ install_using_package_manager() {
         sudo yum install -y $package
       fi
       ;;
-    arch)
+    arch | manjaro)
       if [[ $1 == $PYTHON_COMMAND ]]
       then
         package="python3 cmake gcc"

--- a/setup.sh
+++ b/setup.sh
@@ -326,7 +326,13 @@ check_and_install_dependencies curl
 
 # check for python3
 check_and_install_dependencies $PYTHON_COMMAND
-check_and_install_dependencies $PIP_COMMAND
+
+# check for pip
+# except on arch and manjaro, where pip is installed with python
+if [[ $OS != "linux" || $ID != "arch" && $ID != "manjaro" ]]
+then
+  check_and_install_dependencies $PIP_COMMAND
+fi
 
 # if OS is linux and ID is amzn install basic dependencies
 if [[ $OS == "linux" && $ID == "amzn" ]]


### PR DESCRIPTION
# Description

Fails building `CMake`. The only reference I could find to the error, `Could NOT find Boost: missing: foobar (found /usr/local/lib/cmake/Boost-1.80.0/BoostConfig.cmake (found suitable version "1.80.0", minimum required is "1.80"))` was [here](https://cmake.org/pipermail/cmake-commits/2019-May/033050.html) but no clues on how to get over it.

Cataloguing here for transparency & then closing.

## Build Error:

```
371/615 Test #377: RunCMake.Configure ................................   Passed    2.58 sec
            Start 378: RunCMake.DisallowedCommands
    372/615 Test #378: RunCMake.DisallowedCommands .......................   Passed    0.30 sec
            Start 379: RunCMake.ExportCompileCommands
    373/615 Test #379: RunCMake.ExportCompileCommands ....................   Passed    0.45 sec
            Start 380: RunCMake.ExcludeFromAll
    374/615 Test #380: RunCMake.ExcludeFromAll ...........................   Passed    0.60 sec
            Start 381: RunCMake.ExportImport
    375/615 Test #381: RunCMake.ExportImport .............................   Passed    0.24 sec
            Start 382: RunCMake.ExternalData
    376/615 Test #382: RunCMake.ExternalData .............................   Passed    0.54 sec
            Start 383: RunCMake.FeatureSummary
    377/615 Test #383: RunCMake.FeatureSummary ...........................   Passed    0.32 sec
            Start 384: RunCMake.FPHSA
    378/615 Test #384: RunCMake.FPHSA ....................................   Passed    0.44 sec
            Start 385: RunCMake.FileAPI
    379/615 Test #385: RunCMake.FileAPI ..................................   Passed    1.75 sec
            Start 386: RunCMake.FindBoost
    380/615 Test #386: RunCMake.FindBoost ................................***Failed    0.25 sec
    -- CMakePackage - PASSED
    -- NoCXX - PASSED
    -- LegacyVars-TargetsDefined - PASSED
    -- LegacyVars-LowercaseTargetPrefix - PASSED
    -- LegacyVars-NoHeaderTarget - PASSED
    -- MissingTarget - PASSED
    -- ConfigMode - PASSED
    -- ModuleMode - PASSED
    CMake Error at /tmp/pip-install-o8ac8f5_/cmake_f6622a4adc3b4294be7a3c0230aef289/CMake-src/Tests/RunCMake/RunCMake.cmake:219 (message):
      ConfigModeNotFound - FAILED:

      Result is [1], not [0].

      Command was:

       command> "/tmp/pip-install-o8ac8f5_/cmake_f6622a4adc3b4294be7a3c0230aef289/_skbuild/freebsd-13.1-RELEASE-p3-amd64-3.9/cmake-build/CMakeProject-build/bin/cmake" "/tmp/pip-install-o8ac8f5_/cmake_f6622a4adc3b4294be7a3c0230aef289/CMake-src/Tests/RunCMake/FindBoost" "-G" "Unix Makefiles" "-DRunCMake_TEST=ConfigModeNotFound" "--no-warn-unused-cli" "-DCMAKE_MAKE_PROGRAM=/usr/local/bin/gmake"

      Actual stdout:

       actual-out> Not searching for unused variables given on the command line.
       actual-out> -- Boost toolset is unknown (compiler  )
       actual-out> -- Boost toolset is unknown (compiler  )
       actual-out> -- Could NOT find Boost: missing: foobar (found /usr/local/lib/cmake/Boost-1.80.0/BoostConfig.cmake (found suitable version "1.80.0", minimum required is "1.80"))
       actual-out> -- Configuring incomplete, errors occurred!
       actual-out> See also "/tmp/pip-install-o8ac8f5_/cmake_f6622a4adc3b4294be7a3c0230aef289/_skbuild/freebsd-13.1-RELEASE-p3-amd64-3.9/cmake-build/CMakeProject-build/Tests/RunCMake/FindBoost/ConfigModeNotFound-build/CMakeFiles/CMakeOutput.log".

      Actual stderr:

       actual-err> CMake Error at /usr/local/lib/cmake/BoostDetectToolset-1.80.0.cmake:5 (string):
       actual-err>   string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
       actual-err>   command.
       actual-err> Call Stack (most recent call first):
       actual-err>   /usr/local/lib/cmake/boost_timer-1.80.0/boost_timer-config.cmake:29 (include)
       actual-err>   /usr/local/lib/cmake/Boost-1.80.0/BoostConfig.cmake:141 (find_package)
       actual-err>   /usr/local/lib/cmake/Boost-1.80.0/BoostConfig.cmake:262 (boost_find_component)
       actual-err>   /tmp/pip-install-o8ac8f5_/cmake_f6622a4adc3b4294be7a3c0230aef289/CMake-src/Modules/FindBoost.cmake:594 (find_package)
       actual-err>   CommonNotFound.cmake:2 (find_package)
       actual-err>   ConfigModeNotFound.cmake:2 (include)
       actual-err>   CMakeLists.txt:3 (include)
       actual-err>
       actual-err>
       actual-err> CMake Error at /usr/local/lib/cmake/BoostDetectToolset-1.80.0.cmake:5 (string):
       actual-err>   string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
       actual-err>   command.
       actual-err> Call Stack (most recent call first):
       actual-err>   /usr/local/lib/cmake/boost_chrono-1.80.0/boost_chrono-config.cmake:29 (include)
       actual-err>   /usr/local/lib/cmake/boost_timer-1.80.0/boost_timer-config.cmake:102 (find_package)
       actual-err>   /usr/local/lib/cmake/Boost-1.80.0/BoostConfig.cmake:141 (find_package)
       actual-err>   /usr/local/lib/cmake/Boost-1.80.0/BoostConfig.cmake:262 (boost_find_component)
       actual-err>   /tmp/pip-install-o8ac8f5_/cmake_f6622a4adc3b4294be7a3c0230aef289/CMake-src/Modules/FindBoost.cmake:594 (find_package)
       actual-err>   CommonNotFound.cmake:2 (find_package)
       actual-err>   ConfigModeNotFound.cmake:2 (include)
       actual-err>   CMakeLists.txt:3 (include)

    Call Stack (most recent call first):
      /tmp/pip-install-o8ac8f5_/cmake_f6622a4adc3b4294be7a3c0230aef289/CMake-src/Tests/RunCMake/FindBoost/RunCMakeTest.cmake:21 (run_cmake)


    -- ModuleModeNotFound - PASSED
    -- CMP0093-NEW - PASSED
    -- CMP0093-OLD - PASSED
    -- CMP0093-UNSET - PASSED

    381/615 Test #368: RunCMake.BuildDepends .............................   Passed   26.09 sec

    99% tests passed, 1 tests failed out of 381

    Label Time Summary:
    CMake      =  66.32 sec*proc (62 tests)
    CUDA       =  11.61 sec*proc (3 tests)
    HIP        =   0.39 sec*proc (1 test)
    ISPC       =   0.39 sec*proc (1 test)
    Label1     =   0.02 sec*proc (1 test)
    Label2     =   0.02 sec*proc (1 test)
    command    =   0.00 sec*proc (0 test)
    policy     =  17.50 sec*proc (36 tests)
    run        =  66.32 sec*proc (62 tests)

    Total Test time (real) = 223.80 sec

    The following tests FAILED:
          386 - RunCMake.FindBoost (Failed)
    Errors while running CTest
    gmake[2]: *** [CMakeFiles/CMakeProject-build.dir/build.make:121: CMakeProject-build-prefix/src/CMakeProject-build-stamp/CMakeProject-build-run_cmake_test_suite] Error 8
    gmake[1]: *** [CMakeFiles/Makefile2:113: CMakeFiles/CMakeProject-build.dir/all] Error 2
    gmake: *** [Makefile:136: all] Error 2
    Traceback (most recent call last):
      File "/tmp/pip-build-env-ii1dgva4/overlay/lib/python3.9/site-packages/skbuild/setuptools_wrap.py", line 649, in setup
        cmkr.make(make_args, install_target=cmake_install_target, env=env)
      File "/tmp/pip-build-env-ii1dgva4/overlay/lib/python3.9/site-packages/skbuild/cmaker.py", line 686, in make
        self.make_impl(clargs=clargs, config=config, source_dir=source_dir, install_target=install_target, env=env)
      File "/tmp/pip-build-env-ii1dgva4/overlay/lib/python3.9/site-packages/skbuild/cmaker.py", line 717, in make_impl
        raise SKBuildError(


        =============================DEBUG ASSISTANCE=============================
        If you are seeing a compilation error please try the following steps to
        successfully install cmake:
        1) Upgrade to the latest pip and try again. This will fix errors for most
           users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
        2) If on Linux, with glibc < 2.12, you can set PIP_ONLY_BINARY=cmake in
           order to retrieve the last manylinux1 compatible wheel.
        3) If on Linux, with glibc < 2.12, you can cap "cmake<3.23" in your
           requirements in order to retrieve the last manylinux1 compatible wheel.
        4) Open an issue with the debug information that follows at
           https://github.com/scikit-build/cmake-python-distributions/issues

        Python: 3.9.16
        platform: FreeBSD-13.1-RELEASE-p3-amd64-64bit-ELF
        machine: amd64
        bits: 64
        pip: n/a
        setuptools: 67.1.0
        scikit-build: 0.16.6
        PEP517_BUILD_BACKEND=setuptools.build_meta
        =============================DEBUG ASSISTANCE=============================

    An error occurred while building with CMake.
      Command:
        /usr/local/bin/cmake --build . --target install --config Release --
      Install target:
        install
      Source directory:
        /tmp/pip-install-o8ac8f5_/cmake_f6622a4adc3b4294be7a3c0230aef289
      Working directory:
        /tmp/pip-install-o8ac8f5_/cmake_f6622a4adc3b4294be7a3c0230aef289/_skbuild/freebsd-13.1-RELEASE-p3-amd64-3.9/cmake-build
    Please check the install target is valid and see CMake's output for more information.
    error: subprocess-exited-with-error

    × Building wheel for cmake (pyproject.toml) did not run successfully.
    │ exit code: 1
    ╰─> See above for output.

    note: This error originates from a subprocess, and is likely not a problem with pip.
    full command: /usr/home/yeldarb/quickstart-python/roboflow/bin/python3.9 /usr/home/yeldarb/quickstart-python/roboflow/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py build_wheel /tmp/tmpb07x9kzr
    cwd: /tmp/pip-install-o8ac8f5_/cmake_f6622a4adc3b4294be7a3c0230aef289
    Building wheel for cmake (pyproject.toml): finished with status 'error'
    ERROR: Failed building wheel for cmake
  Failed to build cmake
  ERROR: Could not build wheels for cmake, which is required to install pyproject.toml-based projects
  error: subprocess-exited-with-error
  
  × pip subprocess to install build dependencies did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /usr/home/yeldarb/quickstart-python/roboflow/bin/python3.9 /usr/home/yeldarb/quickstart-python/roboflow/lib/python3.9/site-packages/pip/__pip-runner__.py install --ignore-installed --no-user --prefix /tmp/pip-build-env-shb4or2h/overlay --no-warn-script-location -v --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools==59.2.0 wheel==0.37.0 'cmake>=3.1' pip 'scikit-build>=0.13.2' 'numpy==1.13.3; python_version=='"'"'3.6'"'"' and platform_machine != '"'"'aarch64'"'"' and platform_machine != '"'"'arm64'"'"'' 'numpy==1.17.0; python_version=='"'"'3.7'"'"' and platform_machine != '"'"'aarch64'"'"' and platform_machine != '"'"'arm64'"'"'' 'numpy==1.17.3; python_version=='"'"'3.8'"'"' and platform_machine != '"'"'aarch64'"'"' and platform_machine != '"'"'arm64'"'"'' 'numpy==1.19.3; python_version<='"'"'3.9'"'"' and sys_platform == '"'"'linux'"'"' and platform_machine == '"'"'aarch64'"'"'' 'numpy==1.21.0; python_version<='"'"'3.9'"'"' and sys_platform == '"'"'darwin'"'"' and platform_machine == '"'"'arm64'"'"'' 'numpy==1.19.3; python_version=='"'"'3.9'"'"' and platform_machine != '"'"'aarch64'"'"' and platform_machine != '"'"'arm64'"'"'' 'numpy==1.21.2; python_version>='"'"'3.10'"'"'' 'numpy==1.21.4; python_version>='"'"'3.10'"'"' and platform_system=='"'"'Darwin'"'"''
  cwd: [inherit]
  Installing build dependencies ... error
error: subprocess-exited-with-error

× pip subprocess to install build dependencies did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```