### PR TITLE
Fix Mac on Fresh Install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -287,6 +287,25 @@ install_using_package_manager() {
         sudo zypper install -y $package
       fi
       ;;
+    gentoo)
+      if [[ $1 == $PYTHON_COMMAND ]]
+      then
+        package="python"
+      fi
+
+      # overwrite node to nodejs
+      if [[ $1 == "node" ]]
+      then
+        package="nodejs npm"
+      fi
+
+      if [[ $2 ]]
+      then
+        echo "sudo emerge $package"
+      else
+        sudo emerge $package
+      fi
+      ;;
     *)
       echo ""
       echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -218,6 +218,17 @@ install_using_package_manager() {
       fi
       ;;
     arch)
+      if [[ $1 == $PYTHON_COMMAND ]]
+      then
+        package="python3 cmake gcc"
+      fi
+
+      # overwrite node to nodejs
+      if [[ $1 == "node" ]]
+      then
+        package="nodejs"
+      fi
+
       if [[ $2 ]]
       then
         echo "sudo pacman -S --noconfirm $package"

--- a/setup.sh
+++ b/setup.sh
@@ -288,6 +288,8 @@ install_using_package_manager() {
       fi
       ;;
     gentoo)
+      USE=""
+
       if [[ $1 == $PYTHON_COMMAND ]]
       then
         package="dev-lang/python"
@@ -303,13 +305,14 @@ install_using_package_manager() {
       if [[ $1 == "node" ]]
       then
         package="net-libs/nodejs"
+        USE=" USE=npm"
       fi
 
       if [[ $2 ]]
       then
-        echo "sudo emerge $package"
+        echo "sudo$USE emerge $package"
       else
-        sudo emerge $package
+        sudo$USE emerge $package
       fi
       ;;
     *)

--- a/setup.sh
+++ b/setup.sh
@@ -226,7 +226,7 @@ install_using_package_manager() {
       # overwrite node to nodejs
       if [[ $1 == "node" ]]
       then
-        package="nodejs"
+        package="nodejs npm"
       fi
 
       if [[ $2 ]]

--- a/setup.sh
+++ b/setup.sh
@@ -305,14 +305,14 @@ install_using_package_manager() {
       if [[ $1 == "node" ]]
       then
         package="net-libs/nodejs"
-        USE=" USE=npm"
+        export USE="npm"
       fi
 
       if [[ $2 ]]
       then
-        echo "sudo$USE emerge $package"
+        echo "sudo emerge $package"
       else
-        sudo$USE emerge $package
+        sudo emerge $package
       fi
       ;;
     *)

--- a/setup.sh
+++ b/setup.sh
@@ -217,6 +217,13 @@ install_using_package_manager() {
         sudo yum install -y $package
       fi
       ;;
+    arch)
+      if [[ $2 ]]
+      then
+        echo "sudo pacman -S --noconfirm $package"
+      else
+        sudo pacman -S --noconfirm $package
+      fi
     *)
       echo ""
       echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -124,6 +124,12 @@ install_using_package_manager() {
   linux)
     source /etc/os-release
 
+    # if the ID starts with opensuse, simplify it to opensuse
+    if [[ $ID =~ "opensuse" ]]
+    then
+      ID="opensuse"
+    fi
+
     package=$1
     case $ID in
     debian | ubuntu | linuxmint | mint)

--- a/setup.sh
+++ b/setup.sh
@@ -235,6 +235,7 @@ install_using_package_manager() {
       else
         sudo pacman -S --noconfirm $package
       fi
+      ;;
     *)
       echo ""
       echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -107,6 +107,13 @@ then
     PYTHON_COMMAND="python3.8"
     PIP_COMMAND="pip3.8"
   fi
+
+  # for suse (ID starts with opensuse) use python3.9 and pip3.9 (because they're in zypper)
+  if [[ $ID =~ "opensuse" ]]
+  then
+    PYTHON_COMMAND="python3.9"
+    PIP_COMMAND="pip3.9"
+  fi
 fi
 
 # modified install_using_package_manager function which accepts a second argument which,
@@ -253,6 +260,25 @@ install_using_package_manager() {
         echo "sudo apk add $package"
       else
         sudo apk add $package
+      fi
+      ;;
+    opensuse)
+      if [[ $1 == $PYTHON_COMMAND ]]
+      then
+        package="python39 python39-pip cmake gcc"
+      fi
+
+      # overwrite node to nodejs
+      if [[ $1 == "node" ]]
+      then
+        package="nodejs npm"
+      fi
+
+      if [[ $2 ]]
+      then
+        echo "sudo zypper install -y $package"
+      else
+        sudo zypper install -y $package
       fi
       ;;
     *)

--- a/setup.sh
+++ b/setup.sh
@@ -236,6 +236,25 @@ install_using_package_manager() {
         sudo pacman -S --noconfirm $package
       fi
       ;;
+    alpine)
+      if [[ $1 == $PYTHON_COMMAND ]]
+      then
+        package="python3 cmake gcc"
+      fi
+
+      # overwrite node to nodejs
+      if [[ $1 == "node" ]]
+      then
+        package="nodejs npm"
+      fi
+
+      if [[ $2 ]]
+      then
+        echo "sudo apk add $package"
+      else
+        sudo apk add $package
+      fi
+      ;;
     *)
       echo ""
       echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -326,9 +326,16 @@ install_using_package_manager() {
     ;;
 
   darwin)
+    # for sha256sum, the package is coreutils
+    package=$1
+    if [[ $1 == "sha256sum" ]]
+    then
+      package="coreutils"
+    fi
+
     if [[ $2 ]]
     then
-      echo "brew install $1"
+      echo "brew install $package"
     else
       # first ensure brew is installed
       if ! command -v brew &> /dev/null
@@ -348,7 +355,7 @@ install_using_package_manager() {
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       fi
 
-      brew install $1
+      brew install $package
     fi
     ;;
 
@@ -404,6 +411,12 @@ check_and_install_dependencies() {
 
 # check for curl
 check_and_install_dependencies curl
+
+# on mac we need coreutils
+if [[ $OS == "darwin" ]]
+then
+  check_and_install_dependencies sha256sum
+fi
 
 # check for python3
 check_and_install_dependencies $PYTHON_COMMAND

--- a/setup.sh
+++ b/setup.sh
@@ -346,9 +346,15 @@ check_and_install_dependencies curl
 # check for python3
 check_and_install_dependencies $PYTHON_COMMAND
 
+# alpine needs some additional build tools
+if [[ $OS == "linux" && $ID == "alpine" ]]
+then
+  apk add python-dev gfortran py-pip build-base
+fi
+
 # check for pip
 # except on fedora, arch, and manjaro, where pip is installed with python
-if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" ]]
+if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" && $ID != "alpine" ]]
 then
   check_and_install_dependencies $PIP_COMMAND
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -290,13 +290,19 @@ install_using_package_manager() {
     gentoo)
       if [[ $1 == $PYTHON_COMMAND ]]
       then
-        package="python"
+        package="dev-lang/python"
+      fi
+
+      # for pip, it's dev-python/pip
+      if [[ $1 == $PIP_COMMAND ]]
+      then
+        package="dev-python/pip"
       fi
 
       # overwrite node to nodejs
       if [[ $1 == "node" ]]
       then
-        package="nodejs npm"
+        package="net-libs/nodejs"
       fi
 
       if [[ $2 ]]

--- a/setup.sh
+++ b/setup.sh
@@ -346,12 +346,6 @@ check_and_install_dependencies curl
 # check for python3
 check_and_install_dependencies $PYTHON_COMMAND
 
-# alpine needs some additional build tools
-if [[ $OS == "linux" && $ID == "alpine" ]]
-then
-  apk add python-dev gfortran py-pip build-base
-fi
-
 # check for pip
 # except on fedora, arch, and manjaro, where pip is installed with python
 if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" && $ID != "alpine" ]]
@@ -404,6 +398,13 @@ export PATH=$PATH:~/.local/bin
 # this will exit when the script ends
 # we cd into the `roboflow` folder we just created so we run as the same user that just created it; this prevents an issue when running as root in docker
 cd roboflow && npx @roboflow/inference-server --yes &> /dev/null &
+
+# alpine needs some additional build tools
+if [[ $OS == "linux" && $ID == "alpine" ]]
+then
+  apk add build-base g++ gfortran jpeg-dev libjpeg make py3-numpy py3-numpy-dev py3-pip python3-dev zlib-dev
+  $PIP_COMMAND -v --log /tmp/pip.log install wheel
+fi
 
 # pip install the requirements
 # and run the roboflow notebook

--- a/setup.sh
+++ b/setup.sh
@@ -347,6 +347,8 @@ install_using_package_manager() {
 
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       fi
+
+      brew install $1
     fi
     ;;
 

--- a/setup.sh
+++ b/setup.sh
@@ -328,8 +328,8 @@ check_and_install_dependencies curl
 check_and_install_dependencies $PYTHON_COMMAND
 
 # check for pip
-# except on arch and manjaro, where pip is installed with python
-if [[ $OS != "linux" || $ID != "arch" && $ID != "manjaro" ]]
+# except on fedora, arch, and manjaro, where pip is installed with python
+if [[ $OS != "linux" || $ID != "fedora" && $ID != "arch" && $ID != "manjaro" ]]
 then
   check_and_install_dependencies $PIP_COMMAND
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -217,7 +217,7 @@ install_using_package_manager() {
         sudo yum install -y $package
       fi
       ;;
-    arch)
+    arch | manjaro)
       if [[ $1 == $PYTHON_COMMAND ]]
       then
         package="python3 cmake gcc"

--- a/setup.sh
+++ b/setup.sh
@@ -326,7 +326,13 @@ check_and_install_dependencies curl
 
 # check for python3
 check_and_install_dependencies $PYTHON_COMMAND
-check_and_install_dependencies $PIP_COMMAND
+
+# check for pip
+# except on arch and manjaro, where pip is installed with python
+if [[ $OS != "linux" || $ID != "arch" && $ID != "manjaro" ]]
+then
+  check_and_install_dependencies $PIP_COMMAND
+fi
 
 # if OS is linux and ID is amzn install basic dependencies
 if [[ $OS == "linux" && $ID == "amzn" ]]


### PR DESCRIPTION
# Description

Looks like the `brew install` command got removed when we added the check for installing brew itself. We also need `coreutils` to run `sha256sum` on Mac which we're now using to generate the auth token.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

On a `mac1.metal` ec2 instance.

## Any specific deployment considerations

No

## Docs

-  Not needed.
