### PR TITLE
Fix typo

### DIFF
--- a/create-models.ipynb
+++ b/create-models.ipynb
@@ -1663,7 +1663,7 @@
    "source": [
     "## Next Up: Roboflow Model Types\n",
     "\n",
-    "Next, we will look into the differnt types of computer vision tasks you can accomplish with Roboflow. \n",
+    "Next, we will look into the different types of computer vision tasks you can accomplish with Roboflow. \n",
     "\n",
     "* Object detection\n",
     "* Classification\n",


### PR DESCRIPTION
# Description

This PR fixes a typo in the `create-models.ipynb` notebook.