### PR TITLE
correct commands to launch subsequent notebook

### DIFF
--- a/create-models.ipynb
+++ b/create-models.ipynb
@@ -1690,9 +1690,10 @@
     }
    ],
    "source": [
-    "from notebook import notebookapp\n",
+    "from notebook import app\n",
+    "from jupyter_server import serverapp\n",
     "import webbrowser\n",
-    "jupyter_server = list(notebookapp.list_running_servers())[0][\"url\"]\n",
+    "jupyter_server = list(serverapp.list_running_servers())[0][\"url\"]\n",
     "webbrowser.open(jupyter_server + \"notebooks/model-types.ipynb\")"
    ]
   }

--- a/model-types.ipynb
+++ b/model-types.ipynb
@@ -223,9 +223,10 @@
     }
    ],
    "source": [
-    "from notebook import notebookapp\n",
+    "from notebook import app\n",
+    "from jupyter_server import serverapp\n",
     "import webbrowser\n",
-    "jupyter_server = list(notebookapp.list_running_servers())[0][\"url\"]\n",
+    "jupyter_server = list(serverapp.list_running_servers())[0][\"url\"]\n",
     "webbrowser.open(jupyter_server + \"notebooks/integration.ipynb\")"
    ]
   },

--- a/quickstart.ipynb
+++ b/quickstart.ipynb
@@ -282,9 +282,10 @@
    ],
    "source": [
     "#onto the next notebook!\n",
-    "from notebook import notebookapp\n",
+    "from notebook import app\n",
+    "from jupyter_server import serverapp\n",
     "import webbrowser\n",
-    "jupyter_server = list(notebookapp.list_running_servers())[0][\"url\"]\n",
+    "jupyter_server = list(serverapp.list_running_servers())[0][\"url\"]\n",
     "webbrowser.open(jupyter_server + \"notebooks/create-models.ipynb\")"
    ]
   }


### PR DESCRIPTION
the final cell in `quickstart.ipynb`, `create-models.ipynb` and `model-types.ipynb` is intended to launch the subsequent notebook in the series, but the following changes need to be made for it to work:
- `notebook` is imported from `app.py`, not `notebookapp.py` -- _`notebookapp.py` doesn't appear to exist_
- `list_running_servers` method is defined in `serverapp.py`, not `app.py` -- _method does not exist in `app.py`_